### PR TITLE
Removed lock from backports dependency

### DIFF
--- a/gh.gemspec
+++ b/gh.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
 
   s.add_runtime_dependency 'faraday',     '~> 0.8'
-  s.add_runtime_dependency 'backports',   '~> 2.3'
+  s.add_runtime_dependency 'backports'
   s.add_runtime_dependency 'multi_json',  '~> 1.0'
   s.add_runtime_dependency 'addressable'
   s.add_runtime_dependency 'net-http-persistent', '>= 2.7'


### PR DESCRIPTION
It was preventing https://github.com/travis-ci/travis from updating to the latest backports version that is required by https://github.com/shopify/dashing and is generally a good idea, I guess.
