### PR TITLE
Include the request payload in the error if the request errors

### DIFF
--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -85,6 +85,9 @@ module GH
         req.body = Response.new(body).to_s if body
       end
       frontend.generate_response(key, response)
+    rescue GH::Error => error
+      error.info[:payload] = Response.new(body).to_s if body
+      raise error
     end
 
     # Public: ...

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -16,6 +16,11 @@ describe GH::Remote do
     expect { subject['foo'] }.to raise_error(GH::Error)
   end
 
+  it 'includes the request payload in errors' do
+    stub_request(:post, "https://api.github.com/foo").to_return(:status => 422)
+    expect { subject.post('foo', :foo => "bar") }.to raise_error { |error| error.message.should =~ /{\s*"foo":\s*"bar"\s*}/ }
+  end
+
   it 'parses the body' do
     stub_request(:get, "https://api.github.com/foo").to_return(:body => '{"foo":"bar"}')
     subject['foo']['foo'].should be == 'bar'


### PR DESCRIPTION
The payload is set to `nil`, but if we have one then we might as well set it.
