### PR TITLE
Escape curly braces in regex

### DIFF
--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -18,7 +18,7 @@ describe GH::Remote do
 
   it 'includes the request payload in errors' do
     stub_request(:post, "https://api.github.com/foo").to_return(:status => 422)
-    expect { subject.post('foo', :foo => "bar") }.to raise_error { |error| error.message.should =~ /{\s*"foo":\s*"bar"\s*}/ }
+    expect { subject.post('foo', :foo => "bar") }.to raise_error { |error| error.message.should =~ /\{\s*"foo":\s*"bar"\s*\}/ }
   end
 
   it 'parses the body' do


### PR DESCRIPTION
The Travis CI build is currently failing on Ruby 1.8 and Ruby Enterprise Edition. This is due to unescaped curly braces in `spec/remote_sepc.rb`, which Ruby 1.9 and above don't seem to interpret specially.
