### PR TITLE
fix(response): handle empty string commits

### DIFF
--- a/lib/gh/response.rb
+++ b/lib/gh/response.rb
@@ -26,7 +26,7 @@ module GH
       when respond_to(:to_str)  then @body = body.to_str
       when respond_to(:to_hash) then @data = body.to_hash
       when respond_to(:to_ary)  then @data = body.to_ary
-      when nil                  then @data = {}
+      when nil, ''              then @data = {}
       else raise ArgumentError, "cannot parse #{body.inspect}"
       end
 


### PR DESCRIPTION
lostisland/faraday@f41ffaabb72d3700338296c79a2084880e6a9843 changed the net-http adapter to return empty strings for empty bodies instead of nil, which then causes the JSON parser to error when attempting to parse it, since an empty string is not valid JSON.
