### PR TITLE
fix(response): handle nil or empty string bodies first

### DIFF
--- a/lib/gh/response.rb
+++ b/lib/gh/response.rb
@@ -23,10 +23,10 @@ module GH
       @headers = Hash[headers.map { |k,v| [k.downcase, v] }]
 
       case body
+      when nil, ''              then @data = {}
       when respond_to(:to_str)  then @body = body.to_str
       when respond_to(:to_hash) then @data = body.to_hash
       when respond_to(:to_ary)  then @data = body.to_ary
-      when nil, ''              then @data = {}
       else raise ArgumentError, "cannot parse #{body.inspect}"
       end
 


### PR DESCRIPTION
The fix in 05a917e1239b27be748b9d61d516ac2069d638e1 didn't work because the `respond_to(:to_str)` case is triggered by the empty string, so we never get to this case. Moving it up the chain seems to fix it.

Sorry for the fix-fix. The previous fix I tested with an old Faraday version, but this one I made sure to test with 0.9.0 and it solves the problem. Not sure if moving this case up causes other issues, but it didn't make any tests fail.
