### PR TITLE
Update homepage

### DIFF
--- a/gh.gemspec
+++ b/gh.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = GH::VERSION
   s.authors     = ["Konstantin Haase"]
   s.email       = ["konstantin.mailinglists@googlemail.com"]
-  s.homepage    = "http://gh.rkh.im/"
+  s.homepage    = "https://github.com/travis-ci/gh"
   s.summary     = %q{layered github client}
   s.description = %q{multi-layer client for the github api v3}
   s.license     = "MIT"


### PR DESCRIPTION
http://gh.rkh.im/ doesn't work for me, so there's no links on https://rubygems.org/gems/gh that will take me to the source. Figured this is probably the one to use now.