### PR TITLE
change project homepage to github

### DIFF
--- a/gh.gemspec
+++ b/gh.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = GH::VERSION
   s.authors     = ["Konstantin Haase"]
   s.email       = ["konstantin.mailinglists@googlemail.com"]
-  s.homepage    = "http://gh.rkh.im/"
+  s.homepage    = "https://github.com/travis-ci/gh"
   s.summary     = %q{layered github client}
   s.description = %q{multi-layer client for the github api v3}
   s.license     = "MIT"


### PR DESCRIPTION
The old URL here was throwing a 404.

This is probably an easier fix than getting http://gh.rkh.im/ back online :smirk_cat: 