### PR TITLE
Accept option

### DIFF
--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -27,9 +27,9 @@ module GH
       @api_host = Addressable::URI.parse(api_host)
       @headers  = {
         "User-Agent"      => options[:user_agent] || "GH/#{GH::VERSION}",
-        "Accept"          => "application/vnd.github.v3+json," \
-                             "application/vnd.github.beta+json;q=0.5," \
-                             "application/json;q=0.1",
+        "Accept"          => options[:accept] || "application/vnd.github.v3+json," \
+                                                 "application/vnd.github.beta+json;q=0.5," \
+                                                 "application/json;q=0.1",
         "Accept-Charset"  => "utf-8",
       }
 

--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -27,9 +27,7 @@ module GH
       @api_host = Addressable::URI.parse(api_host)
       @headers  = {
         "User-Agent"      => options[:user_agent] || "GH/#{GH::VERSION}",
-        "Accept"          => options[:accept] || "application/vnd.github.v3+json," \
-                                                 "application/vnd.github.beta+json;q=0.5," \
-                                                 "application/json;q=0.1",
+        "Accept"          => options[:accept] || "application/vnd.github.v3+json",
         "Accept-Charset"  => "utf-8",
       }
 

--- a/spec/custom_limit_spec.rb
+++ b/spec/custom_limit_spec.rb
@@ -9,7 +9,7 @@ describe GH::CustomLimit do
   it 'adds client_id and client_secret to a request' do
     headers = {
       "User-Agent"     => "GH/#{GH::VERSION}",
-      "Accept"         => "application/vnd.github.v3+json,application/vnd.github.beta+json;q=0.5,application/json;q=0.1",
+      "Accept"         => "application/vnd.github.v3+json",
       "Accept-Charset" => "utf-8"
     }
 

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -43,7 +43,7 @@ describe GH::Remote do
       .with(:headers => {"Accept" => "application/vnd.github.v3+json,application/json"})
       .to_return(:body => '["foo"]')
 
-    GH::Remote.new(accept: "application/vnd.github.v3+json,application/json")['foo'].to_s.should be == '["foo"]'
+    GH::Remote.new(:accept => "application/vnd.github.v3+json,application/json")['foo'].to_s.should be == '["foo"]'
   end
 
   describe :path_for do

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -40,7 +40,7 @@ describe GH::Remote do
 
   it 'loads resources from github' do
     stub_request(:get, "https://api.github.com/foo")
-      .with(headers: {"Accept" => "application/vnd.github.v3+json,application/json"})
+      .with(:headers => {"Accept" => "application/vnd.github.v3+json,application/json"})
       .to_return(:body => '["foo"]')
 
     GH::Remote.new(accept: "application/vnd.github.v3+json,application/json")['foo'].to_s.should be == '["foo"]'

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -39,10 +39,7 @@ describe GH::Remote do
   end
 
   it 'loads resources from github' do
-    stub_request(:get, "https://api.github.com/foo")
-      .with(:headers => {"Accept" => "application/vnd.github.v3+json,application/json"})
-      .to_return(:body => '["foo"]')
-
+    stub_request(:get, "https://api.github.com/foo").with(:headers => {"Accept" => "application/vnd.github.v3+json,application/json"}).to_return(:body => '["foo"]')
     GH::Remote.new(:accept => "application/vnd.github.v3+json,application/json")['foo'].to_s.should be == '["foo"]'
   end
 

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -38,6 +38,14 @@ describe GH::Remote do
     wrapper.delete '/foo'
   end
 
+  it 'loads resources from github' do
+    stub_request(:get, "https://api.github.com/foo")
+      .with(headers: {"Accept" => "application/vnd.github.v3+json,application/json"})
+      .to_return(:body => '["foo"]')
+
+    GH::Remote.new(accept: "application/vnd.github.v3+json,application/json")['foo'].to_s.should be == '["foo"]'
+  end
+
   describe :path_for do
     subject { GH::Remote.new }
     before { subject.setup("http://localhost/api/v3", {}) }


### PR DESCRIPTION
We're getting odd responses using the beta header, I'm pretty sure github changed something in the servers, but this fixes the issue.

Without this change:

```
> g = GH.with(token: t)
> g.fetch_resource("/user/emails").body
=> "[\"david.calavera@gmail.com\"]"
```

With this patch:

```
> g = GH.with(token: t)
> g.fetch_resource("/user/emails").body
=> "[{\"email\":\"david.calavera@gmail.com\",\"primary\":true,\"verified\":true}]"
```