### PR TITLE
Allow delete requests to have a body

### DIFF
--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -96,8 +96,8 @@ module GH
     end
 
     # Public: ...
-    def delete(key)
-      frontend.request(:delete, key)
+    def delete(key, body = nil)
+      frontend.request(:delete, key, body)
     end
 
     # Public: ...

--- a/spec/remote_spec.rb
+++ b/spec/remote_spec.rb
@@ -34,7 +34,7 @@ describe GH::Remote do
 
   it 'sends request calls through the frontend' do
     wrapper = Class.new(GH::Wrapper).new
-    wrapper.should_receive(:request).with(:delete, "/foo").and_return GH::Response.new
+    wrapper.should_receive(:request).with(:delete, "/foo", nil).and_return GH::Response.new
     wrapper.delete '/foo'
   end
 


### PR DESCRIPTION
I don't know if this bug has always existed, or maybe the GitHub
API has been extended since this gem was written. But there are
cases where a `DELETE` request needs to send a body, for example:

https://developer.github.com/v3/repos/contents/#delete-a-file

This adds a body param, but sets the default value to `nil` in
order to keep existing code from breaking.