### PR TITLE
Retry wrapper

### DIFF
--- a/lib/gh.rb
+++ b/lib/gh.rb
@@ -14,6 +14,7 @@ module GH
   autoload :Normalizer, 'gh/normalizer'
   autoload :Pagination, 'gh/pagination'
   autoload :Parallel, 'gh/parallel'
+  autoload :Retry, 'gh/retry'
   autoload :Remote, 'gh/remote'
   autoload :Response, 'gh/response'
   autoload :ResponseXHeaderFormatter, 'gh/response_x_header_formatter'

--- a/lib/gh/retry.rb
+++ b/lib/gh/retry.rb
@@ -1,0 +1,41 @@
+require 'gh'
+
+module GH
+  # Public: In some cases, the GitHub API can take some number of
+  # seconds to reflect a change in the system. This class catches 404
+  # responses for any GET request and retries the request.
+  class Retry < Wrapper
+    DEFAULTS = {
+      retries: 5,
+      wait: 1
+    }
+
+    attr_accessor :retries, :wait
+
+    def initialize(backend = nil, options = {})
+      options = DEFAULTS.merge options
+      super backend, options
+    end
+
+    def fetch_resource(key)
+      begin
+        decrement_retries!
+        super key
+      rescue GH::Error(response_status: 404) => e
+        retries_remaining? or raise e
+        sleep wait
+        fetch_resource key
+      end
+    end
+
+    private
+
+    def decrement_retries!
+      self.retries = self.retries - 1
+    end
+
+    def retries_remaining?
+      retries > 0
+    end
+  end
+end

--- a/spec/retry_spec.rb
+++ b/spec/retry_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe GH::Retry do
+  let(:not_finder) do
+    Class.new(GH::MockBackend) do
+      def fetch_resource(key)
+        if key =~ %r{users/not-found}
+          @requests << key
+          error = Struct.new(:info).new(response_status: 404)
+          raise GH::Error.new(error)
+        end
+        super(key)
+      end
+    end
+  end
+
+  subject { described_class.new(not_finder.new, retries: 3, wait: 0.1) }
+
+  it 'retries request specified number of times' do
+    expect { subject['users/not-found'] }.to raise_error(GH::Error)
+    expect(subject.backend.requests.count).to eq 3
+  end
+
+  it 'does not retry when response is successful' do
+    subject['users/rkh']
+    expect(subject.backend.requests.count).to eq 1
+  end
+end


### PR DESCRIPTION
**For discussion**

We're getting 404s quite frequently from the GitHub API when
we request pull request data that appears to take a while to
propagate through the GitHub system.

These errors usually cause a Sidekiq job to raise and be retried,
and the second or third attempt is eventually successful. But
it causes a lot of noise in our logs and the errors are too generic
to catch/ignore.

This adds a `GH::Retry` wrapper that will make a specified number
of retries before raising the 404 as usual.

``` ruby
stack = GH::Stack.build do
  use GH::Retry, retries: 3, wait: 2
end

GH.with(stack) { GH['users/rkh'] }
```
