### PR TITLE
improves authentication method of API calls to GitHub

### DIFF
--- a/lib/gh/token_check.rb
+++ b/lib/gh/token_check.rb
@@ -18,7 +18,7 @@ module GH
       @check_token = false
 
       auth_header = "Basic %s" % Base64.encode64("#{client_id}:#{client_secret}").gsub("\n", "")
-      http :head, path_for("/applications/#{client_id}/tokens/#{token}?client_id=#{client_id}&client_secret=#{client_secret}"), "Authorization" => auth_header
+      http :head, path_for("/applications/#{client_id}/tokens/#{token}"), "Authorization" => auth_header
     rescue GH::Error(:response_status => 404) => error
       raise GH::TokenInvalid, error
     end

--- a/spec/token_check_spec.rb
+++ b/spec/token_check_spec.rb
@@ -8,7 +8,7 @@ describe GH::TokenCheck do
   end
 
   it 'adds client_id and client_secret to a request' do
-    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz?client_id=foo&client_secret=bar", "Authorization" => "Basic Zm9vOmJhcg==") do
+    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 404
       raise error
@@ -18,7 +18,7 @@ describe GH::TokenCheck do
 
   it 'does not swallow other status codes' do
     pending "test needs rewrite for newer RSpec"
-    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz?client_id=foo&client_secret=bar", "Authorization" => "Basic Zm9vOmJhcg==") do
+    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 500
       raise error


### PR DESCRIPTION
Fixes #21 

According to GitHub API [check an authorization](https://developer.github.com/v3/oauth_authorizations/#check-an-authorization), only basic authentication is required. It adds risk of Oauth client secret leakage when using client secret in query string.
