### PR TITLE
Travis: jruby-9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ dist: trusty
 rvm:
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - rbx-2
   - jruby-head
 before_install:
-  - gem update bundler
+  - gem install bundler
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 rvm:
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.5.0
+  - jruby-9.1.13.0
   - rbx-2
   - jruby-head
 before_install:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html

---

Use `gem install bundler` instead of `gem update bundler`.