### PR TITLE
Avoid including too many backports

### DIFF
--- a/lib/gh.rb
+++ b/lib/gh.rb
@@ -1,5 +1,5 @@
 require 'gh/version'
-require 'backports' if RUBY_VERSION < '2.1'
+require 'backports/2.1' if RUBY_VERSION < '2.1'
 require 'forwardable'
 
 module GH


### PR DESCRIPTION
I'm looking at the gem using `backports` to fix usage of `require 'backports'` as a whole before actually deprecating it.

Looking at the `.travis.yml`, it looks like Ruby 2.1 is no longer supported (tests are 2.3.3+ only). Is that the case?

If, so `backports` could be removed altogether. Otherwise, please merge this.

In all cases, consider specifying `required_ruby_version = '>= ??'` in the gemspec :smile: