### PR TITLE
Use new API endpoint to validate token

### DIFF
--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -75,7 +75,8 @@ module GH
 
     # Internal: ...
     def http(verb, url, headers = {}, &block)
-      connection.run_request(verb, url, nil, headers, &block)
+      body = headers.delete :body
+      connection.run_request(verb, url, body, headers, &block)
     rescue Exception => error
       raise Error.new(error, nil, :verb => verb, :url => url, :headers => headers)
     end

--- a/lib/gh/token_check.rb
+++ b/lib/gh/token_check.rb
@@ -18,7 +18,7 @@ module GH
       @check_token = false
 
       auth_header = "Basic %s" % Base64.encode64("#{client_id}:#{client_secret}").gsub("\n", "")
-      http :head, path_for("/applications/#{client_id}/tokens/#{token}?client_id=#{client_id}&client_secret=#{client_secret}"), "Authorization" => auth_header
+      http :post, path_for("/applications/#{client_id}/token"), :body => "{\"access_token\": \"#{token}\"}", "Authorization" => auth_header
     rescue GH::Error(:response_status => 404) => error
       raise GH::TokenInvalid, error
     end

--- a/spec/token_check_spec.rb
+++ b/spec/token_check_spec.rb
@@ -8,7 +8,7 @@ describe GH::TokenCheck do
   end
 
   it 'adds client_id and client_secret to a request' do
-    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz?client_id=foo&client_secret=bar", "Authorization" => "Basic Zm9vOmJhcg==") do
+    subject.backend.should_receive(:http).with(:post, "/applications/foo/token?access_token=baz", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 404
       raise error
@@ -18,7 +18,7 @@ describe GH::TokenCheck do
 
   it 'does not swallow other status codes' do
     pending "test needs rewrite for newer RSpec"
-    subject.backend.should_receive(:http).with(:head, "/applications/foo/tokens/baz?client_id=foo&client_secret=bar", "Authorization" => "Basic Zm9vOmJhcg==") do
+    subject.backend.should_receive(:http).with(:post, "/applications/foo/token?access_token=baz", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 500
       raise error

--- a/spec/token_check_spec.rb
+++ b/spec/token_check_spec.rb
@@ -8,7 +8,7 @@ describe GH::TokenCheck do
   end
 
   it 'adds client_id and client_secret to a request' do
-    subject.backend.should_receive(:http).with(:post, "/applications/foo/token?access_token=baz", "Authorization" => "Basic Zm9vOmJhcg==") do
+    expect(subject.backend).to receive(:http).with(:post, "/applications/foo/token", :body => "{\"access_token\": \"baz\"}", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 404
       raise error
@@ -17,12 +17,11 @@ describe GH::TokenCheck do
   end
 
   it 'does not swallow other status codes' do
-    pending "test needs rewrite for newer RSpec"
-    subject.backend.should_receive(:http).with(:post, "/applications/foo/token?access_token=baz", "Authorization" => "Basic Zm9vOmJhcg==") do
+    expect(subject.backend).to receive(:http).with(:post, "/applications/foo/token", :body => "{\"access_token\": \"baz\"}", "Authorization" => "Basic Zm9vOmJhcg==") do
       error = GH::Error.new
       error.info[:response_status] = 500
       raise error
     end
-    expect { subject['/x'] }.not_to raise_error
+    expect { subject['/x'] }.to raise_error(GH::Error(:response_status => 500))
   end
 end


### PR DESCRIPTION
The new endpoint
https://developer.github.com/v3/apps/oauth_applications/#check-a-token
replaces
https://developer.github.com/v3/apps/oauth_applications/#check-an-authorization

https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/
https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/