### PR TITLE
Updated merge commit ref url

### DIFF
--- a/lib/gh/merge_commit.rb
+++ b/lib/gh/merge_commit.rb
@@ -41,7 +41,7 @@ module GH
     end
 
     def pull_request_refs(hash)
-      link = git_url_for(hash, 'refs/pull/\1')
+      link = git_url_for(hash, 'matching-refs/pull/\1/merge')
       commits = self[link].map do |data|
         ref = data['ref']
         name = ref.split('/').last + "_commit"


### PR DESCRIPTION
Changed merge commit url query url to
https://developer.github.com/v3/git/refs/#list-matching-references
This solves https://travis-ci.community/t/build-checks-out-wrong-pull-request-79-instead-of-7/