### PR TITLE
Customize Faraday logger formatter

### DIFF
--- a/lib/gh.rb
+++ b/lib/gh.rb
@@ -16,6 +16,7 @@ module GH
   autoload :Parallel,         'gh/parallel'
   autoload :Remote,           'gh/remote'
   autoload :Response,         'gh/response'
+  autoload :ResponseXHeaderFormatter, 'gh/response_x_header_formatter'
   autoload :ResponseWrapper,  'gh/response_wrapper'
   autoload :Stack,            'gh/stack'
   autoload :TokenCheck,       'gh/token_check'

--- a/lib/gh/remote.rb
+++ b/lib/gh/remote.rb
@@ -1,5 +1,6 @@
 require 'gh'
 require 'faraday'
+require 'active_support/core_ext/string'
 
 module GH
   # Public: This class deals with HTTP requests to Github. It is the base Wrapper you always want to use.
@@ -50,6 +51,7 @@ module GH
         if defined? FaradayMiddleware::Instrumentation
           builder.use :instrumentation
         end
+        builder.response(:logger, nil, formatter: GH.const_get(options[:formatter].camelize)) if options[:formatter]
         builder.adapter(:net_http)
       end
     end

--- a/lib/gh/response_x_header_formatter.rb
+++ b/lib/gh/response_x_header_formatter.rb
@@ -1,0 +1,12 @@
+require 'faraday/logging/formatter'
+
+module GH
+  class ResponseXHeaderFormatter < Faraday::Logging::Formatter
+    def request(env)
+    end
+
+    def response(env)
+      info('Response') { env.response_headers.select {|k,v| k =~ /^x-/}.sort.to_h }
+    end
+  end
+end


### PR DESCRIPTION
In particular, add the ability to log `X-*` response headers. GitHub
provides useful information such as `x-github-request-id`. With this
option, we get the following logs:

    [1] pry(main)> require 'gh'
    => true
    [2] pry(main)> GH.set :formatter => 'response_x_header_formatter'
    => {:formatter=>"response_x_header_formatter"}
    [3] pry(main)> GH.head '/'
    I, [2020-06-24T17:27:02.309042 #15465]  INFO -- Response: {"x-content-type-options"=>"nosniff", "x-frame-options"=>"deny", "x-github-media-type"=>"github.v3; format=json", "x-github-request-id"=>"F786:7114:AF4F41:12EC65F:5EF3C526", "x-ratelimit-limit"=>"60", "x-ratelimit-remaining"=>"58", "x-ratelimit-reset"=>"1593037573", "x-xss-protection"=>"1; mode=block"}
    => {"_links"=>{"self"=>{"href"=>"https://api.github.com/"}}}